### PR TITLE
fix : use global prisma instance

### DIFF
--- a/actions/create_job.ts
+++ b/actions/create_job.ts
@@ -1,5 +1,5 @@
 "use server";
-import prisma from "../db/prisma";
+import { prisma } from "../lib/prisma";
 import cloudinary from "../lib/bucket";
 import { JobStatus } from "@prisma/client";
 //import {getServerSession} from "next-auth";

--- a/actions/delete_job.ts
+++ b/actions/delete_job.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import prisma from "@/db/prisma";
+import { prisma } from "../lib/prisma";
 
 const deleteJob = async (job_id: string) => {
   try {

--- a/actions/getJobByID.ts
+++ b/actions/getJobByID.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import prisma from "../db/prisma";
+import { prisma } from "../lib/prisma";
 
 const getJobById = async (jobId: string) => {
   console.log(jobId);

--- a/actions/getJobTags.ts
+++ b/actions/getJobTags.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import prisma from "../db/prisma";
+import { prisma } from "../lib/prisma";
 
 const getJobTags = async () => {
   const result = await prisma.jobTag.findMany();

--- a/actions/getReviews.ts
+++ b/actions/getReviews.ts
@@ -1,4 +1,4 @@
-import prisma from "../db/prisma";
+import { prisma } from "../lib/prisma";
 
 const getReviews = async () => {
   const results = await prisma.review.findMany({

--- a/actions/getUserInfo.ts
+++ b/actions/getUserInfo.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import prisma from "../db/prisma";
+import { prisma } from "../lib/prisma";
 
 const getEmployerInfoById = async (userId: string) => {
   const result = await prisma.employer.findFirst({

--- a/actions/lookup/employee/jobs.ts
+++ b/actions/lookup/employee/jobs.ts
@@ -1,7 +1,6 @@
 "use server";
-import { PrismaClient, JobStatus, ApplicationStatus } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { JobStatus, ApplicationStatus } from "@prisma/client";
+import { prisma } from "../../../lib/prisma";
 
 export interface job {
   id: string;

--- a/actions/register.ts
+++ b/actions/register.ts
@@ -1,9 +1,7 @@
 "use server";
 import { EmailRegisterSchema } from "@/schemas/EmailRegisterSchema";
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "../lib/prisma"
 import bcrypt from "bcrypt";
-
-const prisma = new PrismaClient();
 
 async function registerWithCredentials(data: {
   email: string;

--- a/actions/search/jobs.ts
+++ b/actions/search/jobs.ts
@@ -1,8 +1,7 @@
 "use server";
-import { PrismaClient, JobStatus, ApplicationStatus } from "@prisma/client";
+import { JobStatus, ApplicationStatus } from "@prisma/client";
+import { prisma } from "../../lib/prisma"
 import { Client } from "@elastic/elasticsearch";
-
-const prisma = new PrismaClient();
 
 const elasticClient = new Client({
   node: process.env.ELASTIC_NODE_URL, // Elasticsearch endpoint

--- a/actions/update_job.ts
+++ b/actions/update_job.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import prisma from "../db/prisma";
+import { prisma } from "../lib/prisma";
 import { revalidatePath } from "next/cache";
 
 const updateJob = async (formData: FormData) => {

--- a/app/api/auth/[...nextauth]/auth.ts
+++ b/app/api/auth/[...nextauth]/auth.ts
@@ -1,10 +1,9 @@
 import { AuthOptions } from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
 import CredentialsProvider from "next-auth/providers/credentials";
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "../../../../lib/prisma";
 import bcrypt from "bcrypt";
 
-const prisma = new PrismaClient();
 
 export const authOptions: AuthOptions = {
   providers: [

--- a/db/prisma.ts
+++ b/db/prisma.ts
@@ -1,9 +1,0 @@
-import { PrismaClient } from "@prisma/client";
-
-const globalForPrisma = global as unknown as { prisma: PrismaClient };
-
-export const prisma = globalForPrisma.prisma || new PrismaClient();
-
-if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
-
-export default prisma;

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,8 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient }
+
+export const prisma =
+    globalForPrisma.prisma || new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma


### PR DESCRIPTION
Due to limited database connection, the prisma client instance needs to be instantiated once. The hot-reloading of nextjs will instantiate the prisma client everytime the page is reloaded as it uses `const prisma = new PrismaClient();`.
From this problem, I use the global prisma client instance from ./lib/prisma.ts for only one prisma client per machine.