### PR TITLE
feat: lib/payment that keep all payment calculation and formatting

### DIFF
--- a/app/(withNavigation)/jobs/[jobId]/payment/[studentId]/page.tsx
+++ b/app/(withNavigation)/jobs/[jobId]/payment/[studentId]/page.tsx
@@ -2,6 +2,7 @@ import {
   getPaymentInfo,
 } from "@/actions/payment/paymentinfo";
 import Payment from "@/components/payment/payment";
+import { calculateRealAmount, calculateComAmount, calculateTotalAmount } from "@/lib/payment";
 
 export default async function PaymentPage({
   params,
@@ -9,6 +10,10 @@ export default async function PaymentPage({
   params: { jobId: string; studentId: string };
 }) {
   const data = await getPaymentInfo(params.jobId, params.studentId);
+  const bid = data?.bid ? (data.bid) : (0);
+  const realAmount = calculateRealAmount(bid);
+  const comAmount = calculateComAmount(bid);
+  const totalAmount = calculateTotalAmount(bid);
 
   return (
     <div className="w-full h-full">
@@ -20,10 +25,12 @@ export default async function PaymentPage({
             ? `${data.user.salutation}${data.user.firstname} ${data.user.middlename || ""} ${data.user.lastname}`
             : ""
         }
-        price={data ? data.bid : 0}
         jobId={params.jobId}
         studentId={params.studentId}
         isDeposit={data ? data.status === "DEPOSIT_PENDING" : false}
+        realAmount={realAmount}
+        comAmount={comAmount}
+        totalAmount={totalAmount}
       />
     </div>
   );

--- a/components/payment/payment.tsx
+++ b/components/payment/payment.tsx
@@ -1,30 +1,33 @@
 import PaymentInformation from "./subPaymentComponent/paymentInformation";
 import PaymentMethod from "./subPaymentComponent/paymentMethod";
 import UploadPayment from "./subPaymentComponent/upLoadPayment";
+
 export default function Payment({
   studentName,
   studentId,
-  price,
   jobId,
   isDeposit,
+  realAmount,
+  comAmount,
+  totalAmount
 }: {
   studentName: string;
   studentId: string;
-  price: number;
   jobId: string;
   isDeposit: boolean;
+  realAmount: number
+  comAmount: number
+  totalAmount: number
 }) {
-  const totalPrice = price * 0.5 * 0.15 + price * 0.5;
-
   return (
     <div className="flex flex-col lg:grid lg:grid-cols-2 lg:grid-rows-5 lg:gap-x-8 lg:gap-y-0 lg:h-auto lg:pt-[24px] lg:px-[50px] lg:text-center lg:justify-center 2xl:px-[200px]">
-      <PaymentInformation studentName={studentName} price={price} />
-      <PaymentMethod totalPrice={parseFloat(totalPrice.toFixed(2))} />
+      <PaymentInformation studentName={studentName} realAmount={realAmount} comAmount={comAmount} totalAmount={totalAmount} />
+      <PaymentMethod totalAmount={totalAmount} />
       <UploadPayment
         label="อัพโหลดสลิปโอนเงิน"
         jobId={jobId}
         studentId={studentId}
-        totalPrice={totalPrice}
+        totalAmount={totalAmount}
         isDeposit={isDeposit}
       />
     </div>

--- a/components/payment/subPaymentComponent/paymentInformation.tsx
+++ b/components/payment/subPaymentComponent/paymentInformation.tsx
@@ -1,10 +1,17 @@
+import { formatPaymentAmountWithCommas } from "@/lib/payment";
+
 export default function PaymentInformation({
   studentName,
-  price,
+  realAmount,
+  comAmount,
+  totalAmount
 }: {
   studentName: string;
-  price: number;
+  realAmount: number;
+  comAmount: number;
+  totalAmount: number;
 }) {
+  
   return (
     <div className="lg:order-2 lg:row-span-2 lg:mt-[13px]">
       <div className="flex">
@@ -26,7 +33,7 @@ export default function PaymentInformation({
           </p>
 
           <p className="text-[#64748b] text-sm lg:text-[18px]">
-            {(price * 0.5).toFixed(2)} บาท
+            {formatPaymentAmountWithCommas(realAmount)} บาท
           </p>
         </div>
 
@@ -36,7 +43,7 @@ export default function PaymentInformation({
           </p>
 
           <p className="text-[#64748b] text-sm lg:text-[18px]">
-            {(price * 0.5 * 0.15).toFixed(2)} บาท
+            {formatPaymentAmountWithCommas(comAmount)} บาท
           </p>
         </div>
 
@@ -46,7 +53,7 @@ export default function PaymentInformation({
           </p>
 
           <p className="text-[#1E293B] text-sm lg:text-[18px]">
-            {(price * 0.5 * 0.15 + price * 0.5).toFixed(2)} บาท
+            {formatPaymentAmountWithCommas(totalAmount)} บาท
           </p>
         </div>
       </div>

--- a/components/payment/subPaymentComponent/paymentMethod.tsx
+++ b/components/payment/subPaymentComponent/paymentMethod.tsx
@@ -5,9 +5,9 @@ import Image from "next/image";
 import generatePayload from "promptpay-qr";
 import QRCode from "react-qr-code";
 
-export default function PaymentMethod({ totalPrice }: { totalPrice: number }) {
+export default function PaymentMethod({ totalAmount }: { totalAmount: number }) {
   const payload = generatePayload(process.env.RECIPIENT_NUMBER || "", {
-    amount: totalPrice,
+    amount: totalAmount,
   });
 
   return (

--- a/components/payment/subPaymentComponent/upLoadPayment.tsx
+++ b/components/payment/subPaymentComponent/upLoadPayment.tsx
@@ -14,11 +14,11 @@ type Props = {
   jobId: string;
   studentId: string;
   isDeposit: boolean;
-  totalPrice: number;
+  totalAmount: number;
 };
 
 export default function FilesInput(props: Props) {
-  const { label, jobId, studentId, isDeposit, totalPrice } = props;
+  const { label, jobId, studentId, isDeposit, totalAmount } = props;
   const [isDisabled, setDisabled] = useState(false);
   const [files, setFiles] = useState<FileList | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -119,7 +119,7 @@ export default function FilesInput(props: Props) {
     formDataObject.append("jobId", jobId);
     formDataObject.append("studentId", studentId);
     formDataObject.append("employerUserId", session.user.id);
-    formDataObject.append("amount", totalPrice.toString());
+    formDataObject.append("amount", totalAmount.toString());
     formDataObject.append("isDeposit", isDeposit.toString());
     formDataObject.append("receipt", selectedFile);
 

--- a/components/paymentHistory/paymentHistoryCard/PaymentHistoryCard.tsx
+++ b/components/paymentHistory/paymentHistoryCard/PaymentHistoryCard.tsx
@@ -36,8 +36,6 @@ export default function PaymentHistoryCard(props: Transaction) {
   const realAmount = getRealAmount(props.amount);
   const comAmount = getCommission(props.amount);
   const totalAmount = props.amount;
-  console.log(realAmount, comAmount, totalAmount)
-  console.log(props.amount)
 
   // Status UI
   const successStatus = (

--- a/components/paymentHistory/paymentHistoryCard/PaymentHistoryCard.tsx
+++ b/components/paymentHistory/paymentHistoryCard/PaymentHistoryCard.tsx
@@ -2,9 +2,8 @@
 
 import { useState } from "react";
 import Image from "next/image";
+import { formatPaymentAmountWithCommas, getRealAmount, getCommission } from "@/lib/payment";
 import downArrowDark from "@/public/icons/downArrowDark.svg";
-
-const comRate = 0.15;
 
 type Transaction = {
   id: string;
@@ -33,6 +32,13 @@ export default function PaymentHistoryCard(props: Transaction) {
   // Open accordion state
   const [isOpen, setOpen] = useState(false);
 
+  // Extract amount
+  const realAmount = getRealAmount(props.amount);
+  const comAmount = getCommission(props.amount);
+  const totalAmount = props.amount;
+  console.log(realAmount, comAmount, totalAmount)
+  console.log(props.amount)
+
   // Status UI
   const successStatus = (
     <p className="border rounded-[6px] border-green-600 text-green-600 text-[11px] md:text-[16px] font-bold px-[8px] py-[3px]">
@@ -50,20 +56,10 @@ export default function PaymentHistoryCard(props: Transaction) {
     </p>
   );
 
-  function getCom(amount: number) {
-    return (getReal(amount)) * comRate;
-  }
-
-  function getReal(amount: number) {
-    return (amount / (1+comRate));
-  }
-
   function formatAmount(amount: number, isStudent: boolean): string {
     const currencySymbol = "฿";
     const studentSign = isStudent ? "+" : "-";
-    let netAmount = amount;
-    if (isStudent) netAmount = getReal(netAmount);
-    const result = `${studentSign} ${currencySymbol}${netAmount.toFixed(2)}`;
+    const result = `${studentSign} ${currencySymbol}${formatPaymentAmountWithCommas(amount)}`;
     return result;
   }
 
@@ -99,7 +95,7 @@ export default function PaymentHistoryCard(props: Transaction) {
           <h1
             className={`font-semibold text-[20px] text-nowrap shrink-0 self-start md:text-[24px] ${props.isStudent ? "text-green-600" : "text-red-500"}`}
           >
-            {formatAmount(props.amount, props.isStudent)}
+            {formatAmount(props.isStudent? (realAmount) : (totalAmount), props.isStudent)}
           </h1>
         </div>
         <div className="flex justify-between">
@@ -130,17 +126,17 @@ export default function PaymentHistoryCard(props: Transaction) {
           <p>
             {props.isDeposit ? "ค่ามัดจำการจ้างงาน" : "ค่าตอบแทนการจ้างงาน"}
           </p>
-          <p>{getReal(props.amount).toFixed(2)} บาท</p>
+          <p>{formatPaymentAmountWithCommas(realAmount)} บาท</p>
         </div>
         {!props.isStudent && (
           <>
             <div className="flex justify-between font-normal text-[14px] md:text-[16px] text-slate-500">
               <p>ค่าบริการ 15 %</p>
-              <p>{getCom(props.amount).toFixed(2)} บาท</p>
+              <p>{formatPaymentAmountWithCommas(comAmount)} บาท</p>
             </div>
             <div className="flex justify-between font-normal text-[14px] md:text-[16px] text-slate-700">
               <p>ยอดชำระทั้งหมด</p>
-              <p>{(props.amount).toFixed(2)} บาท</p>
+              <p>{formatPaymentAmountWithCommas(totalAmount)} บาท</p>
             </div>
           </>
         )}

--- a/lib/payment.ts
+++ b/lib/payment.ts
@@ -1,0 +1,40 @@
+const decimalPlace = 2;
+const depositeRatio = 0.5;
+const comRate = 0.15;
+
+// PAYMENT (input is bid)
+export function calculateRealAmount(bid: number) {
+    return roundPaymentAmount(bid * depositeRatio)
+}
+
+export function calculateComAmount(bid: number) {
+    return roundPaymentAmount(calculateRealAmount(bid) * comRate)
+}
+
+export function calculateTotalAmount(bid: number) {
+    return roundPaymentAmount(calculateRealAmount(bid) + calculateComAmount(bid))
+}
+
+// PATMENT HISTORY (input is totalAmount)
+export function getCommission(totalAmount: number) {
+    return roundPaymentAmount(getRealAmount(totalAmount)) * comRate;
+}
+
+export function getRealAmount(totalAmount: number) {
+    return roundPaymentAmount(totalAmount / (1+comRate));
+}
+
+// FORMATTED
+export function formatPaymentAmountWithCommas(amount: number): string {
+    // Fixing to 2 decimal places
+    const fixedAmount = amount.toFixed(decimalPlace);
+    const [wholePart, decimalPart] = fixedAmount.split('.');
+    const formattedDecimalPart = decimalPart.padEnd(2, '0');
+    return `${wholePart}.${formattedDecimalPart}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+// ROUND FLOAT
+export function roundPaymentAmount(amount: number): number {
+    // Fixing to 2 decimal places
+    return parseFloat(amount.toFixed(decimalPlace));
+}


### PR DESCRIPTION
- แก้ฟอร์แมทของตัวเลขในหน้า payment และ payment-history ให้มีทศนิยม 2 ตำแหน่ง + comma
- รวมการคำนวณค่า realAmount (ค่าเงินจริงที่นิสิตจะได้รับ), comAmount (ค่าคอมที่บริษัทจะได้) และ totalAmount (real + com) ไว้ใน lib/payment.ts